### PR TITLE
Let docker understand TLS and TCP connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,18 @@ RUN set -x && \
     apk update && \
     apk upgrade && \
     apk add \
-        python2 \
-        && \
+    python2 \
+    python2-dev \
+    gcc \
+    musl-dev \
+    libffi-dev \
+    openssl-dev \
+    && \
     \
     curl https://bootstrap.pypa.io/get-pip.py | python - && \
     pip install \
             cloudflare \
-            docker \
+            docker[tls] \
             && \
     \
 ### Cleanup

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -13,6 +13,9 @@ services:
       - TARGET_DOMAIN=host.example.org
       - DOMAIN1=example.org
       - DOMAIN1_ZONE_ID=1234567890
+      #- DOCKER_HOST=tcp://198.51.100.32:2376
+      #- DOCKER_CERT_PATH=/docker-certs
+      #- DOCKER_TLS_VERIFY=1
     networks:
     - internal
     - services

--- a/install/assets/defaults/10-cloudflare-companion
+++ b/install/assets/defaults/10-cloudflare-companion
@@ -1,5 +1,4 @@
 #!/usr/bin/with-contenv bash
 
 DEFAULT_TTL=${DEFAULT_TTL:-1}
-DOCKER_ENDPOINT=${DOCKER_ENDPOINT:-"unix://var/run/docker.sock"}
 TRAEFIK_VERSION=${TRAEFIK_VERSION:-1}

--- a/install/etc/cont-init.d/10-cloudflare-companion
+++ b/install/etc/cont-init.d/10-cloudflare-companion
@@ -114,7 +114,7 @@ target_domain = os.environ['TARGET_DOMAIN']
 domain = os.environ['DOMAIN1']
 
 cf = CloudFlare.CloudFlare(email=email , token=token)
-client = docker.DockerClient(base_url='${DOCKER_ENDPOINT}')
+client = docker.from_env()
 
 init()
 


### PR DESCRIPTION
Use docker.from_env() instead of docker.DockerClient() and
use optional system environments DOCKER_HOST, DOCKER_TLS_VERIFY and
DOCKER_CERT_PATH.
This commits also builds docker with TLS support.