### PR TITLE
Add cloudflare API token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ Along with the Environment Variables from the [Base image](https://hub.docker.co
 | ------------------- | ------------------------------------------------------------------------------ |
 | `TRAEFIK_VERSION`   | What version of Traefik do you want to work against - `1` or `2` - Default `1` |
 | `DOCKER_ENTRYPOINT` | Docker Entrypoint default `unix://var/run/docker.sock`                         |
-| `CF_EMAIL`          | Email address tied to Cloudflare Account                                       |
-| `CF_TOKEN`          | Token for the Domain                                                           |
+| `CF_API_EMAIL`      | Email address tied to Cloudflare Account for usage with the Global API key     |
+| `CF_API_KEY`        | Global API Key or API Token if used without email address                      |
 | `DEFAULT_TTL`       | TTL to apply to records - Default `1` (auto)                                   |
-| `TARGET_DOMAIN`     | Destination Host to forward records to e.g. `host.example.com`                |
+| `TARGET_DOMAIN`     | Destination Host to forward records to e.g. `host.example.com`                 |
 | `DOMAIN1`           | Domain 1 you wish to update records for.                                       |
 | `DOMAIN1_ZONE_ID`   | Domain 1 Zone ID from Cloudflare                                               |
 | `DOMAIN1_PROXIED`   | Domain 1 True of False if proxied                                              |

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -8,11 +8,10 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     environment:
       - TRAEFIK_VERSION=2
-      - CF_EMAIL=email@example.com
-      - CF_TOKEN=1234
+      - CF_API_KEY=5uaY5WTNEGXB7xXsvz2jVA2wVsCKTgGp
       - TARGET_DOMAIN=host.example.org
       - DOMAIN1=example.org
-      - DOMAIN1_ZONE_ID=1234567890
+      - DOMAIN1_ZONE_ID=fbSx3dk3A3mJ6UukLQ7zRbo63H5UdsGSCqQnTvbJDgyQaTp
       #- DOCKER_HOST=tcp://198.51.100.32:2376
       #- DOCKER_CERT_PATH=/docker-certs
       #- DOCKER_TLS_VERIFY=1

--- a/install/etc/cont-init.d/10-cloudflare-companion
+++ b/install/etc/cont-init.d/10-cloudflare-companion
@@ -5,8 +5,6 @@ prepare_service single
 PROCESS_NAME="traefik-cloudflare-companion"
 
 ### Sanity Test
-sanity_var CF_EMAIL "Cloudflare Email"
-sanity_var CF_TOKEN "Cloudflare Token"
 sanity_var TARGET_DOMAIN "Target Domain"
 sanity_var DOMAIN1 "Domain 1"
 sanity_var DOMAIN1_ZONE_ID "Domain 1 Zone ID"
@@ -108,12 +106,10 @@ def init():
     for c in client.containers.list(all=True):
         check_container(c)
 
-email = os.environ['CF_EMAIL']
-token = os.environ['CF_TOKEN']
 target_domain = os.environ['TARGET_DOMAIN']
 domain = os.environ['DOMAIN1']
 
-cf = CloudFlare.CloudFlare(email=email , token=token)
+cf = CloudFlare.CloudFlare()
 client = docker.from_env()
 
 init()


### PR DESCRIPTION
This patch makes it possible to use Cloudflare new API Tokens feature. This makes the Cloudflare account safer by not requiring administrator permissions given with the Global API Key.