### PR TITLE
Check for existing record and delete if exists

### DIFF
--- a/install/etc/cont-init.d/10-cloudflare-companion
+++ b/install/etc/cont-init.d/10-cloudflare-companion
@@ -44,7 +44,24 @@ EOF
                 proxied_flag${i} = False
 
             if name.find(domain${i}) != -1:
-                r = cf.zones.dns_records.post(zone_id${i},data={u'type': u'CNAME', u'name': name, u'content': target_domain, u'ttl': ${DEFAULT_TTL}, u'proxied': proxied_flag${i}} )
+                try:
+                    records = cf.zones.dns_records.get(zone_id${i}, params={u'name':name})
+                    data_dict = {
+                        u'type': u'CNAME', 
+                        u'name': name, 
+                        u'content': target_domain, 
+                        u'ttl': ${DEFAULT_TTL}, 
+                        u'proxied': proxied_flag${i}
+                    }
+                    if len(records) == 0:
+                        cf.zones.dns_records.post(zone_id${i},data=data_dict)
+                        print "Created new record: ", name
+                    else:
+                        for record in records:
+                            cf.zones.dns_records.put(zone_id${i}, record["id"], data=data_dict)
+                            print "Updated existing record: ", name
+                except CloudFlare.exceptions.CloudFlareAPIError as e:
+                    pass
 
 EOF
         fi


### PR DESCRIPTION
This PR checks for an existing DNS record before posting.
This means that the rpevious record can be deleted first.

The use cases for this are:

* A record has already been created with an incorrect TARGET_HOST CNAME
* A legacy record exists which needs overwriting
* A record exists with the wrong proxied flag
* A record exists with the wrong TTL

Note: This change has NOT been tested!