### PR TITLE
Get labels from service for docker swarm

### DIFF
--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -145,8 +145,8 @@ def check_service_t2(s, doms):
          print ("[debug] Called check_service_t2 for:", s)
     cont_id = s
     s = client.services.get(s)
-    for prop in s.attrs.get(u'Spec').get(u'TaskTemplate').get(u'ContainerSpec').get(u'Labels'):
-         value = s.attrs.get(u'Spec').get(u'TaskTemplate').get(u'ContainerSpec').get(u'Labels').get(prop)
+    for prop in s.attrs.get(u'Spec').get(u'Labels'):
+         value = s.attrs.get(u'Spec').get(u'Labels').get(prop)
          if re.match('traefik.*?\.rule', prop):
             if 'Host' in value:
                 if CONTAINER_LOG_LEVEL == "DEBUG" :


### PR DESCRIPTION
Traefik in swarm mode stores the labels on the service and not on the container.

When you use Traefik with Docker Swarm you define the labels on the service:
https://doc.traefik.io/traefik/providers/docker/#configuration-examples
```yaml
version: "3"
services:
  my-container:
    deploy:
      labels:
        - traefik.http.routers.my-container.rule=Host(`example.com`)
        - traefik.http.services.my-container-service.loadbalancer.server.port=8080
```

This fixes #22 