### PR TITLE
Add option for domain specific target_domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,11 @@ Along with the Environment Variables from the [Base image](https://hub.docker.co
 | `DOMAIN1`           | Domain 1 you wish to update records for.                                                |                              |
 | `DOMAIN1_ZONE_ID`   | Domain 1 Zone ID from Cloudflare                                                        |                              |
 | `DOMAIN1_PROXIED`   | Domain 1 True or False if proxied                                                       |                              |
+| `DOMAIN1_TARGET_DOMAIN` | (optional Domain 1 specific target domain)                                                       |                              |
 | `DOMAIN2`           | (optional Domain 2 you wish to update records for.)                                     |                              |
 | `DOMAIN2_ZONE_ID`   | Domain 2 Zone ID from Cloudflare                                                        |                              |
 | `DOMAIN2_PROXIED`   | Domain 1 True or False if proxied                                                       |                              |
+| `DOMAIN2_TARGET_DOMAIN`   | (optional Domain 2 specific target domain)                                                       |                              |
 | `DOMAIN3....`       | And so on..                                                                             |                              |
 
 ### Docker Secrets

--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ Along with the Environment Variables from the [Base image](https://hub.docker.co
 | `DOMAIN1`           | Domain 1 you wish to update records for.                                                |                              |
 | `DOMAIN1_ZONE_ID`   | Domain 1 Zone ID from Cloudflare                                                        |                              |
 | `DOMAIN1_PROXIED`   | Domain 1 True or False if proxied                                                       |                              |
-| `DOMAIN1_TARGET_DOMAIN` | (optional Domain 1 specific target domain)                                                       |                              |
+| `DOMAIN1_TARGET_DOMAIN` | (optional specify target_domain for Domain 1, overriding the default value from TARGET_DOMAIN)                                          |                              |
 | `DOMAIN2`           | (optional Domain 2 you wish to update records for.)                                     |                              |
 | `DOMAIN2_ZONE_ID`   | Domain 2 Zone ID from Cloudflare                                                        |                              |
 | `DOMAIN2_PROXIED`   | Domain 1 True or False if proxied                                                       |                              |
-| `DOMAIN2_TARGET_DOMAIN`   | (optional Domain 2 specific target domain)                                                       |                              |
+| `DOMAIN2_TARGET_DOMAIN`   | (optional specify target_domain for Domain 2, overriding the default value from TARGET_DOMAIN)                                     |                              |
 | `DOMAIN3....`       | And so on..                                                                             |                              |
 
 ### Docker Secrets

--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -59,11 +59,11 @@ def point_domain(name, doms):
                 try:
                     if len(records) == 0:
                         r = cf.zones.dns_records.post(dom['zone_id'], data=data)
-                        print ("[info] Created new record:", name, "to point to", dom['target_domain'])
+                        print("[info] Created new record:", name, "to point to", dom['target_domain'])
                     else:
                         for record in records:
                             cf.zones.dns_records.put(dom['zone_id'], record["id"], data=data)
-                            print ("[info] Updated existing record:", name, "to point to", dom['target_domain'])
+                            print("[info] Updated existing record:", name, "to point to", dom['target_domain'])
                 except CloudFlare.exceptions.CloudFlareAPIError as e:
                     pass
             else:

--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -30,6 +30,7 @@ def init_doms_from_env():
                 'proxied': os.environ.get("{}_PROXIED".format(k), "FALSE").upper() == "TRUE",
                 'zone_id': os.environ["{}_ZONE_ID".format(k)],
                 'ttl': os.environ.get("{}_TTL".format(k), DEFAULT_TTL),
+                'target_domain': os.environ.get("{}_TARGET_DOMAIN".format(k), target_domain),
             }
 
             doms.append(dom)
@@ -47,7 +48,7 @@ def point_domain(name, doms):
             data = {
                 u'type': u'CNAME',
                 u'name': name,
-                u'content': target_domain,
+                u'content': dom['target_domain'],
                 u'ttl': dom['ttl'],
                 u'proxied': dom['proxied']
             }
@@ -55,17 +56,17 @@ def point_domain(name, doms):
                 try:
                     if len(records) == 0:
                         r = cf.zones.dns_records.post(dom['zone_id'], data=data)
-                        print ("[info] Created new record:", name, "to point to", target_domain)
+                        print ("[info] Created new record:", name, "to point to", dom['target_domain'])
                     else:
                         for record in records:
                             cf.zones.dns_records.put(dom['zone_id'], record["id"], data=data)
-                            print ("[info] Updated existing record:", name, "to point to", target_domain)
+                            print ("[info] Updated existing record:", name, "to point to", dom['target_domain'])
                 except CloudFlare.exceptions.CloudFlareAPIError as e:
                     pass
             else:
                 try:
                     r = cf.zones.dns_records.post(dom['zone_id'], data=data)
-                    print ("[info] Created new record:", name, "to point to", target_domain)
+                    print("[info] Created new record:", name, "to point to", dom['target_domain'])
 
                 except CloudFlare.exceptions.CloudFlareAPIError as e:
                     print('** %s - %d %s' % (name, e, e))

--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -43,6 +43,9 @@ def init_doms_from_env():
 
 def point_domain(name, doms):
     for dom in doms:
+        if name == dom['target_domain']:
+            continue
+
         if name.find(dom['name']) >= 0:
             records = cf.zones.dns_records.get(dom['zone_id'], params={u'name':name})
             data = {


### PR DESCRIPTION
This should implement the requested feature in https://github.com/tiredofit/docker-traefik-cloudflare-companion/issues/28

And also will solve the problem mentioned in https://github.com/tiredofit/docker-traefik-cloudflare-companion/issues/7#issuecomment-695751017. So it won't attempt to create a cname for the main domain. 