### PR TITLE
Support alternative syntax for traefik2 multihosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ For those wishing to assign multiple CNAMEs to a container use the following for
 
 - Traefik 2.x
 ````bash
+  - traefik.http.routers.example.rule=Host(`example1.domain.tld`, `example2.domain.tld`)
+````
+or
+````bash
   - traefik.http.routers.example.rule=Host(`example1.domain.tld`) || Host(`example2.domain.tld`)
 ````
 
@@ -103,7 +107,8 @@ Along with the Environment Variables from the [Base image](https://hub.docker.co
 
 ### Docker Secrets
 
-`CF_EMAIL` and `CF_TOKEN` support Docker Secrets
+`CF_EMAIL` and `CF_TOKEN` support Docker Secrets.
+Name your secrets either CF_EMAIL and CF_TOKEN or cf_email and cf_token. 
 
 ## Maintenance
 ### Shell Access

--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -135,11 +135,9 @@ def check_container_t2(c, doms):
         value = c.attrs.get(u'Config').get(u'Labels').get(prop)
         if re.match('traefik.*?\.rule', prop):
             if 'Host' in value:
-                if CONTAINER_LOG_LEVEL == "DEBUG":
-                    print("[debug] Container ID:", cont_id, "rule value:", value)
+                logger.debug("Container ID: %s rule value:%s", cont_id, value)
                 extracted_domains = re.findall(r'\`([a-zA-Z0-9\.]+)\`', value)
-                if CONTAINER_LOG_LEVEL == "DEBUG":
-                    print("[debug] Container ID:", cont_id, "extracted domains from rule:", extracted_domains)
+                logger.debug("Container ID: %s extracted domains from rule: %s", cont_id, extracted_domains)
                 if len(extracted_domains) > 1:
                     for v in extracted_domains:
                         logger.info("Found Service ID: %s with Multi-Hostname %s", cont_id, v)
@@ -159,11 +157,9 @@ def check_service_t2(s, doms):
         value = s.attrs.get(u'Spec').get(u'Labels').get(prop)
         if re.match('traefik.*?\.rule', prop):
             if 'Host' in value:
-                if CONTAINER_LOG_LEVEL == "DEBUG":
-                    print("[debug] Service ID:", cont_id, "rule value:", value)
+                logger.debug("Service ID: %s rule value: %s", cont_id, value)
                 extracted_domains = re.findall(r'\`([a-zA-Z0-9\.]+)\`', value)
-                if CONTAINER_LOG_LEVEL == "DEBUG":
-                    print("[debug] Service ID:", cont_id, "extracted domains from rule:", extracted_domains)
+                logger.debug("Service ID: %s extracted domains from rule: %s", cont_id, extracted_domains)
                 if len(extracted_domains) > 1:
                     for v in extracted_domains:
                         logger.info("Found Service ID: %s with Multi-Hostname %s", cont_id, v)

--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -137,7 +137,7 @@ def check_container_t2(c, doms):
             if 'Host' in value:
                 if CONTAINER_LOG_LEVEL == "DEBUG":
                     print("[debug] Container ID:", cont_id, "rule value:", value)
-                extracted_domains = re.findall(r'Host.*?\(`(.*?)`\)', value)
+                extracted_domains = re.findall(r'\`([a-zA-Z0-9\.]+)\`', value)
                 if CONTAINER_LOG_LEVEL == "DEBUG":
                     print("[debug] Container ID:", cont_id, "extracted domains from rule:", extracted_domains)
                 if len(extracted_domains) > 1:
@@ -161,7 +161,7 @@ def check_service_t2(s, doms):
             if 'Host' in value:
                 if CONTAINER_LOG_LEVEL == "DEBUG":
                     print("[debug] Service ID:", cont_id, "rule value:", value)
-                extracted_domains = re.findall(r'Host.*?\(`(.*?)`\)', value)
+                extracted_domains = re.findall(r'\`([a-zA-Z0-9\.]+)\`', value)
                 if CONTAINER_LOG_LEVEL == "DEBUG":
                     print("[debug] Service ID:", cont_id, "extracted domains from rule:", extracted_domains)
                 if len(extracted_domains) > 1:


### PR DESCRIPTION
The following host rule syntax is valid within traefik:

"Host(`subdomain.domain.com`,`subdomain2.domain.com`,`subdomain3.domain.com`)"

This configuration was incorrectly parsed previously, and the 'Host' portion
of regex is safe to remove based on the "if 'Host' in value:" check.

Originally added by dchidell at https://github.com/tiredofit/docker-traefik-cloudflare-companion/pull/15 . 
Just updated it for the current code base. Updated the check_service_t2 method as well as updated the documentation


Fixes: https://github.com/tiredofit/docker-traefik-cloudflare-companion/issues/16