### PR TITLE
Fix accidental wrong named variable in log call

### DIFF
--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -145,7 +145,7 @@ def check_container_t2(c, doms):
                         logger.info("Found Service ID: %s with Multi-Hostname %s", cont_id, v)
                         point_domain(v, doms)
                 elif len(extracted_domains) == 1:
-                    logger.info("Found Service ID: %s with Hostname %s", cont_id, v)
+                    logger.info("Found Service ID: %s with Hostname %s", cont_id, extracted_domains[0])
                     point_domain(extracted_domains[0], doms)
             else:
                 pass
@@ -169,7 +169,7 @@ def check_service_t2(s, doms):
                         logger.info("Found Service ID: %s with Multi-Hostname %s", cont_id, v)
                         point_domain(v, doms)
                 elif len(extracted_domains) == 1:
-                    logger.info("Found Service ID: %s with Hostname %s", cont_id, v)
+                    logger.info("Found Service ID: %s with Hostname %s", cont_id, extracted_domains[0])
                     point_domain(extracted_domains[0], doms)
             else:
                 pass


### PR DESCRIPTION
Sorry accidentally missed to update one variable name when changing to the logging module

The current code before this fix will generate 

> File "/usr/sbin/cloudflare-companion", line 148, in check_container_t2
>     logger.info("Found Service ID: %s with Hostname %s", cont_id, v)
> UnboundLocalError: local variable 'v' referenced before assignment
> 
