### PR TITLE
Fixed missing domain name support for services.

### DIFF
--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -187,7 +187,7 @@ def check_service_t2(s, doms):
         if re.match('traefik.*?\.rule', prop):
             if 'Host' in value:
                 logger.debug("Service ID: %s rule value: %s", cont_id, value)
-                extracted_domains = re.findall(r'\`([a-zA-Z0-9\.]+)\`', value)
+                extracted_domains = re.findall(r'\`([a-zA-Z0-9\.\-]+)\`', value)
                 logger.debug("Service ID: %s extracted domains from rule: %s", cont_id, extracted_domains)
                 if len(extracted_domains) > 1:
                     for v in extracted_domains:


### PR DESCRIPTION
The services routine that parses domain names is missing a `\-` in the regex that the container version has. This prevents services with domain names containing hyphens from being properly parsed. i.e. a service with `Host('service.foo.bar')` is parsed and registered correctly, but `Host('service.fo-o.bar')` fails and is returned as null. 

Hope this helps!