### PR TITLE
Added  _FILE environment variables for secrets

### DIFF
--- a/install/etc/cont-init.d/10-cloudflare-companion
+++ b/install/etc/cont-init.d/10-cloudflare-companion
@@ -7,6 +7,5 @@ PROCESS_NAME="traefik-cloudflare-companion"
 ### Sanity Test
 sanity_var TARGET_DOMAIN "Target Domain"
 sanity_var DOMAIN1 "Domain 1"
-sanity_var DOMAIN1_ZONE_ID "Domain 1 Zone ID"
 
 liftoff

--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -389,11 +389,27 @@ def uri_valid(x):
     except:
         return False
 
+def get_secret_by_env(envvar_name):
+    secret_value:str
+    envvar_secret_name=envvar_name + "_FILE"
+    envvar_secret_value=os.getenv(envvar_secret_name)
+    if envvar_secret_value:
+        secret_value = get_docker_secret(envvar_secret_value, secrets_dir='/', autocast_name=False, getenv=False)
+    else:
+        # fallback check for original environment variable
+        secret_value = get_docker_secret(envvar_name, autocast_name=False, getenv=True)
+    if secret_value:
+        logger.debug("Setting environment variable '%s' by docker secret '%s'.", envvar_name, envvar_secret_name)
+        os.environ[envvar_name] = secret_value
+        return secret_value
 
 try:
     # Check for uppercase docker secrets or env variables
-    email = get_docker_secret('CF_EMAIL', autocast_name=False, getenv=True)
-    token = get_docker_secret('CF_TOKEN', autocast_name=False, getenv=True)
+    email = get_envBySecret('CF_EMAIL')
+    token = get_envBySecret('CF_TOKEN')
+
+    get_envBySecret('DOMAIN1_ZONE_ID')
+    get_envBySecret('DOMAIN2_ZONE_ID')
 
     # Check for lowercase docker secrets
     if not email:

--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -408,8 +408,13 @@ try:
     email = get_secret_by_env('CF_EMAIL')
     token = get_secret_by_env('CF_TOKEN')
 
-    get_secret_by_env('DOMAIN1_ZONE_ID')
-    get_secret_by_env('DOMAIN2_ZONE_ID')
+    # Check for any cf zone id based on the respective domain env var existing
+    RX_DOMS = re.compile('^DOMAIN[0-9]+$', re.IGNORECASE)
+    for env in os.environ:
+        if not RX_DOMS.match(env):
+            continue
+
+        get_secret_by_env("{}_ZONE_ID".format(env))
 
     # Check for lowercase docker secrets
     if not email:

--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -405,11 +405,11 @@ def get_secret_by_env(envvar_name):
 
 try:
     # Check for uppercase docker secrets or env variables
-    email = get_envBySecret('CF_EMAIL')
-    token = get_envBySecret('CF_TOKEN')
+    email = get_secret_by_env('CF_EMAIL')
+    token = get_secret_by_env('CF_TOKEN')
 
-    get_envBySecret('DOMAIN1_ZONE_ID')
-    get_envBySecret('DOMAIN2_ZONE_ID')
+    get_secret_by_env('DOMAIN1_ZONE_ID')
+    get_secret_by_env('DOMAIN2_ZONE_ID')
 
     # Check for lowercase docker secrets
     if not email:


### PR DESCRIPTION
Many docker containers use the _FILE or FILE_ prefix or suffix for existing environment variables to denote the secrets file location (i.e. `/run/secrets/<name>`). I would consider it best practice.

The old/current code forces specific secret names on the user which I don't think is optimal. The current code forces the user to have a secret called "CF_EMAIL", which doesn't work well if working with docker stacks and potentially multiple containers that would need different "CF_EMAIL" secrets.

I personally prefer the _FILE syntax, i.e. `CF_EMAIL_FILE=/run/secrets/cloudflare_email` and also being able to name the secrets arbitrarily (such as "cloudflare_email" as in the previous example).

The old code still exists, just as a fallback if _FILE isn't used and for backward compatibility. I unfortunately had to remove the check for the `DOMAIN1_ZONE_ID` since this may be filled at a later stage with the secret. I also added DOMAIN1_ZONE_ID & DOMAIN2_ZONE_ID to the secrets since I think these should be kept secret.

Since I added a function for getting the secrets, more secrets can be added easily.

I'm successfully running this in my deployment using mounts:
```yaml
    volumes:
      - $DOCKERDIR/cf-companion/cloudflare-companion:/usr/sbin/cloudflare-companion
      - $DOCKERDIR/cf-companion/10-cloudflare-companion:/etc/cont-init.d/10-cloudflare-companion
```