### PR TITLE
Add docker mode flag to allow running inside of kubernetes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ For those wishing to assign multiple CNAMEs to a container use the following for
 ### Persistent Storage
 | File                   | Description                                                              |
 | ---------------------- | ------------------------------------------------------------------------ |
-| `/var/run/docker.sock` | You must have access to the docker socket in order to utilize this image |
+| `/var/run/docker.sock` | Required by default unless you set `DOCKER_MODE=FALSE` |
 
 * * *
 ### Environment Variables
@@ -108,6 +108,7 @@ Be sure to view the following repositories to understand all the customizable op
 | Parameter           | Description                                                                             | Default                      |
 | ------------------- | --------------------------------------------------------------------------------------- | ---------------------------- |
 | `TRAEFIK_VERSION`   | What version of Traefik do you want to work against - `1` or `2`                        | `2`                          |
+| `DOCKER_MODE`       | Set this to `FALSE` if you don't have `/var/run/docker.sock` (Kubernetes for example)    | `TRUE`                       | 
 | `DOCKER_ENTRYPOINT` | Docker Entrypoint default (local mode)                                                  | `unix://var/run/docker.sock` |
 | `DOCKER_HOST`       | (optional) If using tcp connection e.g. `tcp://111.222.111.32:2376`                     |                              |
 | `DOCKER_CERT_PATH`  | (optional) If using tcp connection with TLS - Certificate location e.g. `/docker-certs` |                              |
@@ -169,6 +170,13 @@ The supported labels are:
 | 1                | `traefik.normal.frontend.rule=Host:example1.domain.tld` | `traefik.normal.frontend.rule=Host:example1.domain.tld,example2.domain.tld` |
 | 2                | ``traefik.http.routers.example.rule=Host(`example1.domain.tld`)`` | ``traefik.http.routers.example.rule=Host(`example1.domain.tld`) || Host(`example2.domain.tld`)`` |
 
+### Kubernetes:
+
+To work with kubernetes, you'll need to set `DOCKER_MODE=FALSE` and `ENABLE_TRAEFIK_POLL=TRUE`. This will disable the default docker code and instead only rely on traefik polling.
+
+You can deploy this container as a sidecar by adding it to `deployment.additionalContainers` in the traefik helm chart values.yaml. ([example](https://gist.github.com/ZackMitkin/edaf3132baf43098ae01563bda924e72))
+
+
 #### Traefik Polling
 
 Traefik Polling mode can be enabled by setting the environment variable `TRAEFIK_VERSION=2`, `ENABLE_TRAEFIK_POLL=TRUE`, and `TRAEFIK_POLL_URL=http://<host>:<port>`.  This will cause cloudflare-companion to poll Traefik every 60s (default) and discover routers and include hosts which match the following rules:
@@ -181,6 +189,7 @@ Traefik Polling mode can be enabled by setting the environment variable `TRAEFIK
 6. Host does not match exclude patterns (default: none)
 
 The polling interval can be configured by setting the environment variable `TRAEFIK_POLL_SECONDS=120`.
+
 
 ##### Filtering
 

--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -6,7 +6,7 @@ from datetime import datetime
 from get_docker_secret import get_docker_secret
 import atexit
 import CloudFlare
-import docker
+
 import os
 import re
 import requests
@@ -14,6 +14,10 @@ import logging
 import time
 import threading
 from urllib.parse import urlparse
+
+DOCKER_MODE = os.environ.get('DOCKER_MODE', "TRUE").lower == "true"
+if DOCKER_MODE:
+  import docker
 
 DEFAULT_TTL = os.environ.get('DEFAULT_TTL', "1")
 SWARM_MODE = os.environ.get('SWARM_MODE', "FALSE")
@@ -24,6 +28,7 @@ TRAEFIK_POLL_URL = os.environ.get('TRAEFIK_POLL_URL', None)
 TRAEFIK_POLL_SECONDS = int(os.environ.get('TRAEFIK_POLL_SECONDS', "60"))
 CONTAINER_LOG_LEVEL = os.environ.get('CONTAINER_LOG_LEVEL', "INFO")
 DRY_RUN = os.environ.get('DRY_RUN', "FALSE")
+
 
 # set up logging
 logger = logging.getLogger(__name__)
@@ -46,6 +51,11 @@ logger.addHandler(ch)
 
 synced_mappings = {}
 
+def get_secret(name, **kwargs):
+  if DOCKER_MODE:
+    return get_docker_secret(name, kwargs)
+  return os.environ.get(name)
+  
 
 class RepeatedTimer(object):
     def __init__(self, interval, function, *args, **kwargs):
@@ -359,12 +369,13 @@ def get_initial_mappings(included_hosts, excluded_hosts):
     logger.debug("Starting Initialization Routines")
 
     mappings = {}
-    for c in client.containers.list():
-        logger.debug("Container List Discovery Loop")
-        if TRAEFIK_VERSION == "1":
-            add_to_mappings(mappings, check_container_t1(c))
-        elif TRAEFIK_VERSION == "2":
-            add_to_mappings(mappings, check_container_t2(c))
+    if DOCKER_MODE:
+        for c in client.containers.list():
+            logger.debug("Container List Discovery Loop")
+            if TRAEFIK_VERSION == "1":
+                add_to_mappings(mappings, check_container_t1(c))
+            elif TRAEFIK_VERSION == "2":
+                add_to_mappings(mappings, check_container_t2(c))
 
     if SWARM_MODE:
         logger.debug("Service List Discovery Loop")
@@ -392,14 +403,14 @@ def uri_valid(x):
 
 try:
     # Check for uppercase docker secrets or env variables
-    email = get_docker_secret('CF_EMAIL', autocast_name=False, getenv=True)
-    token = get_docker_secret('CF_TOKEN', autocast_name=False, getenv=True)
+    email = get_secret('CF_EMAIL', autocast_name=False, getenv=True)
+    token = get_secret('CF_TOKEN', autocast_name=False, getenv=True)
 
     # Check for lowercase docker secrets
     if not email:
-        email = get_docker_secret('CF_EMAIL', autocast_name=True, getenv=True)
+        email = get_secret('CF_EMAIL', autocast_name=True, getenv=True)
     if not token:
-        token = get_docker_secret('CF_TOKEN', autocast_name=True, getenv=True)
+        token = get_secret('CF_TOKEN', autocast_name=True, getenv=True)
 
     target_domain = os.environ['TARGET_DOMAIN']
     domain = os.environ['DOMAIN1']
@@ -455,7 +466,8 @@ if ENABLE_TRAEFIK_POLL:
 
 logger.debug("Traefik Polling Mode: %s", False)
 
-client = docker.from_env()
+if DOCKER_MODE:
+    client = docker.from_env()
 
 if SWARM_MODE:
     api = docker.APIClient()
@@ -476,36 +488,36 @@ t = datetime.now().strftime("%s")
 
 logger.debug("Time: %s", t)
 
-for event in client.events(since=t, filters={'Type': 'service', 'Action': u'update', 'status': u'start'}, decode=True):
-    new_mappings = {}
-    if event.get(u'status') == u'start':
-        try:
-            if TRAEFIK_VERSION == "1":
-                add_to_mappings(new_mappings, check_container_t1(client.containers.get(event.get(u'id'))))
-                if SWARM_MODE:
-                    add_to_mappings(new_mappings, check_service_t1(client.services.get(event.get(u'id'))))
-            elif TRAEFIK_VERSION == "2":
-                add_to_mappings(new_mappings, check_container_t2(client.containers.get(event.get(u'id'))))
-                if SWARM_MODE:
-                    add_to_mappings(new_mappings, check_service_t2(client.services.get(event.get(u'id'))))
+if DOCKER_MODE:
+  for event in client.events(since=t, filters={'Type': 'service', 'Action': u'update', 'status': u'start'}, decode=True):
+      new_mappings = {}
+      if event.get(u'status') == u'start':
+          try:
+              if TRAEFIK_VERSION == "1":
+                  add_to_mappings(new_mappings, check_container_t1(client.containers.get(event.get(u'id'))))
+                  if SWARM_MODE:
+                      add_to_mappings(new_mappings, check_service_t1(client.services.get(event.get(u'id'))))
+              elif TRAEFIK_VERSION == "2":
+                  add_to_mappings(new_mappings, check_container_t2(client.containers.get(event.get(u'id'))))
+                  if SWARM_MODE:
+                      add_to_mappings(new_mappings, check_service_t2(client.services.get(event.get(u'id'))))
+          except docker.errors.NotFound as e:
+              pass
 
-        except docker.errors.NotFound as e:
-            pass
+      if SWARM_MODE:
+          if event.get(u'Action') == u'update':
+              try:
+                  if TRAEFIK_VERSION == "1":
+                      node_id = event.get(u'Actor').get(u'ID')
+                      logger.debug("Detected Update on node: %s", node_id)
+                      add_to_mappings(new_mappings, check_service_t1(node_id))
+                  elif TRAEFIK_VERSION == "2":
+                      node_id = event.get(u'Actor').get(u'ID')
+                      service_id = client.services.list()
+                      logger.debug("Detected Update on node: %s", node_id)
+                      add_to_mappings(new_mappings, check_service_t2(node_id))
 
-    if SWARM_MODE:
-        if event.get(u'Action') == u'update':
-            try:
-                if TRAEFIK_VERSION == "1":
-                    node_id = event.get(u'Actor').get(u'ID')
-                    logger.debug("Detected Update on node: %s", node_id)
-                    add_to_mappings(new_mappings, check_service_t1(node_id))
-                elif TRAEFIK_VERSION == "2":
-                    node_id = event.get(u'Actor').get(u'ID')
-                    service_id = client.services.list()
-                    logger.debug("Detected Update on node: %s", node_id)
-                    add_to_mappings(new_mappings, check_service_t2(node_id))
+              except docker.errors.NotFound as e:
+                  pass
 
-            except docker.errors.NotFound as e:
-                pass
-
-    sync_mappings(new_mappings, doms)
+      sync_mappings(new_mappings, doms)


### PR DESCRIPTION
I wasn't able to find any alternatives for kubernetes but was able to make this work inside of kubernetes with a few minor patches. 

Running on Kubernetes will rely only on polling method but still works very well.

Note: This only works with Traefik V2 on kubernetes since no support for polling in V1.