### PR TITLE
Fix bug affecting multiple excluded domains

### DIFF
--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -144,8 +144,8 @@ def is_domain_excluded(name, dom):
         if name.find(fqdn_with_sub_dom) != -1:
             logger.info('Ignoring %s because it falls until excluded sub domain: %s', name, sub_dom)
             return True
-        else:
-            return False
+
+    return False
 
 
 def is_matching(host, regexes):


### PR DESCRIPTION
`is_domain_excluded` is returning `False` any time there is not a match against the first subdomain in the array, causing failures to exclude when multiple subdomains are present.