### PR TITLE
Fix REFRESH_ENTRIES default in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Be sure to view the following repositories to understand all the customizable op
 | `DOCKER_HOST`       | (optional) If using tcp connection e.g. `tcp://111.222.111.32:2376`                     |                              |
 | `DOCKER_CERT_PATH`  | (optional) If using tcp connection with TLS - Certificate location e.g. `/docker-certs` |                              |
 | `DOCKER_TLS_VERIFY` | (optional) If using tcp conneciton to socket Verify TLS                                 | `1`                          |
-| `REFRESH_ENTRIES`   | If record exists, update entry with new values `TRUE` or `FALSE`                        | `TRUE`                       |
+| `REFRESH_ENTRIES`   | If record exists, update entry with new values `TRUE` or `FALSE`                        | `FALSE`                      |
 | `SWARM_MODE`        | Enable Docker Swarm Mode `TRUE` or `FALSE`                                              | `FALSE`                      |
 | `ENABLE_TRAEFIK_POLL`      | Enable Traefik Polling Mode `TRUE` or `FALSE`                                           | `FALSE`                      |
 | `TRAEFIK_POLL_URL`       | (optional) If using Traefik Polling mode - URL to Traefik API endpoint                  |                              |


### PR DESCRIPTION
The default value for this environment variable is incorrect in the documentation.

In the code, the real default is false:
https://github.com/tiredofit/docker-traefik-cloudflare-companion/blob/99654084957618f7e4a5eed628318af314915409/install/usr/sbin/cloudflare-companion#L21