### PR TITLE
fix multi host traefik v2

### DIFF
--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -313,7 +313,7 @@ def check_traefik(included_hosts, excluded_hosts):
                         value = router["rule"]
                         if 'Host' in value:
                             logger.debug("Traefik Router Name: %s rule value: %s", name, value)
-                            extracted_domains = re.findall(r'Host\(\`([a-zA-Z0-9\.\-]+)\`\)', value)
+                            extracted_domains = re.findall(r'\`([a-zA-Z0-9\.\-]+)\`', value)
                             logger.debug("Traefik Router Name: %s extracted domains from rule: %s", name, extracted_domains)
                             if len(extracted_domains) > 1:
                                 for v in extracted_domains:


### PR DESCRIPTION
Tweaked the regex for traefik hosts so it can include the multi host rule ```Host(`a`,`b`) ```