### PR TITLE
Fixed invalid escape sequence errors

### DIFF
--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -286,7 +286,7 @@ def check_container_t2(c):
     def label_host():
         for prop in c.attrs.get(u'Config').get(u'Labels'):
             value = c.attrs.get(u'Config').get(u'Labels').get(prop)
-            if re.match('traefik.*?\.rule', prop):
+            if re.match(r'traefik.*?\.rule', prop):
                 if 'Host' in value:
                     logger.debug("Container ID: %s rule value: %s", cont_id, value)
                     extracted_domains = re.findall(r'\`([a-zA-Z0-9\.\-]+)\`', value)
@@ -319,7 +319,7 @@ def check_service_t2(s):
     def label_host():
         for prop in s.attrs.get(u'Spec').get(u'Labels'):
            value = s.attrs.get(u'Spec').get(u'Labels').get(prop)
-           if re.match('traefik.*?\.rule', prop):
+           if re.match(r'traefik.*?\.rule', prop):
                if 'Host' in value:
                    logger.debug("Service ID: %s rule value: %s", cont_id, value)
                    extracted_domains = re.findall(r'\`([a-zA-Z0-9\.\-]+)\`', value)


### PR DESCRIPTION
Two regex errors popped up in my logs recently. This pull request makes the rule a raw string so that the expressions are properly evaluated. 

The error: 
`cloudflare-companion  | 2024-08-02.22:14:58 [STARTING] ** [traefik-cloudflare-companion] [1] Starting Traefik Cloudflare Companion
cloudflare-companion  | /usr/sbin/cloudflare-companion:289: SyntaxWarning: invalid escape sequence '\.'
cloudflare-companion  |   if re.match('traefik.*?\.rule', prop):
cloudflare-companion  | /usr/sbin/cloudflare-companion:322: SyntaxWarning: invalid escape sequence '\.'
cloudflare-companion  |   if re.match('traefik.*?\.rule', prop):`

After the fix: 
`cloudflare-companion  | 2024-08-02.22:17:08 [STARTING] ** [traefik-cloudflare-companion] [1] Starting Traefik Cloudflare Companion
cloudflared-tunnel    | 2024-08-03T05:17:08Z INF Registered tunnel connection connIndex=2 connection=<ID> event=0 ip=<IP> location=<LOC>protocol=quic`