### PR TITLE
Fix crash if API return error

### DIFF
--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -203,7 +203,7 @@ def point_domain(name, domain_infos):
                         else:
                             logger.info("Existing record: %s already points to %s", name, domain_info['target_domain'])
             except CloudflareAPIError as ex:
-                logger.error('** %s - %d %s' % (name, ex, ex))
+                logger.error('** %s - %s %s' % (name, ex, ex))
                 ok = False
                 pass
     return ok


### PR DESCRIPTION
Fix the crash app because of the incorrect return value

Note:  `%d` in `logger.error('** %s - %d %s' % (name, ex, ex))` expects an integer, but `ex` is an object.

Full crash log:
```
Traceback (most recent call last): File "/usr/sbin/cloudflare-companion", line 545, in <module> sync_mappings(get_initial_mappings(traefik_included_hosts, traefik_excluded_hosts), doms) File "/usr/sbin/cloudflare-companion", line 399, in sync_mappings if point_domain(k, domain_infos): ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/usr/sbin/cloudflare-companion", line 206, in point_domain logger.error('** %s - %d %s' % (name, ex, ex)) ~ TypeError: %d format: a real number is required, not BadRequestError
```