### PR TITLE
Fix logger call to use record.id instead of record["id"]

### DIFF
--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -196,7 +196,7 @@ def point_domain(name, domain_infos):
                     for record in records:
                         if record.content != domain_info['target_domain'] or REFRESH_ENTRIES:
                             if DRY_RUN:
-                                logger.info("DRY-RUN: PUT to Cloudflare %s, %s:, %s", domain_info['zone_id'], record["id"], data)
+                                logger.info("DRY-RUN: PUT to Cloudflare %s, %s:, %s", domain_info['zone_id'], record.id, data)
                             else:
                                 cf.dns.records.update(zone_id=domain_info['zone_id'], dns_record_id=record.id, **data)
                                 logger.info("Updated existing record: %s to point to %s", name, domain_info['target_domain'])


### PR DESCRIPTION
Fixes issue when running in dry-run mode:
```
cloudflare-companion  | Traceback (most recent call last):
cloudflare-companion  |   File "/usr/sbin/cloudflare-companion", line 545, in <module>
cloudflare-companion  |     sync_mappings(get_initial_mappings(traefik_included_hosts, traefik_excluded_hosts), doms)
cloudflare-companion  |   File "/usr/sbin/cloudflare-companion", line 399, in sync_mappings
cloudflare-companion  |     if point_domain(k, domain_infos):
cloudflare-companion  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cloudflare-companion  |   File "/usr/sbin/cloudflare-companion", line 199, in point_domain
cloudflare-companion  |     logger.info("DRY-RUN: PUT to Cloudflare %s, %s:, %s", domain_info['zone_id'], record["id"], data)
cloudflare-companion  |                                                                                   ~~~~~~^^^^^^
cloudflare-companion  | TypeError: 'CNAME' object is not subscriptable
```