### PR TITLE
Add the RUN_DELAY variable for service startup delay.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Be sure to view the following repositories to understand all the customizable op
 | `LOG_FILE`  | Log Filename                                                        | `tcc.log` |
 | `LOG_PATH`  | Log Path                                                            | `/logs/`  |
 | `TCC_USER`  | User to run application as (there is a user `tcc` that can be used) | `root`    |
+| `RUN_DELAY` | Delay service startup by specified seconds                          | `0`       |
 
 #### Docker Options
 

--- a/install/etc/services.available/10-cloudflare-companion/run
+++ b/install/etc/services.available/10-cloudflare-companion/run
@@ -6,6 +6,14 @@ PROCESS_NAME="traefik-cloudflare-companion"
 
 check_container_initialized
 check_service_initialized init
+
+# Delay service startup by specified seconds   
+RUN_DELAY="${RUN_DELAY:=0}"
+if [[ ${RUN_DELAY} -gt 0 ]]; then
+    print_info "Delaying service startup by ${RUN_DELAY} seconds"
+    sleep "${RUN_DELAY}"
+fi
+
 liftoff
 
 print_start "Starting Traefik Cloudflare Companion"


### PR DESCRIPTION
When using docker-compose, if a service uses depends_on, it will cause traefik-cloudflare-companion to start before other services, resulting in the initial container scan directly ignoring these services that use depends_on.

To solve this problem, I provided a RUN_DELAY parameter that allows traefik-cloudflare-companion to delay for a specified number of seconds when starting, ensuring that other services have enough time to start and be scanned.