### PR TITLE
Refactor error logging to use f-string format

### DIFF
--- a/install/usr/sbin/cloudflare-companion
+++ b/install/usr/sbin/cloudflare-companion
@@ -203,7 +203,7 @@ def point_domain(name, domain_infos):
                         else:
                             logger.info("Existing record: %s already points to %s", name, domain_info['target_domain'])
             except CloudflareAPIError as ex:
-                logger.error('** %s - %d %s' % (name, ex, ex))
+                logger.error(f"** {name} - {ex}")
                 ok = False
                 pass
     return ok


### PR DESCRIPTION
Change the format as it led to an exception:
> logger.error('** %s - %d %s' % (name, ex, ex))
TypeError: %d format: a real number is required, not BadRequestError